### PR TITLE
Remove unused libraries.

### DIFF
--- a/Peregrine.pde
+++ b/Peregrine.pde
@@ -48,10 +48,10 @@ import controlP5.*;
 import processing.serial.*;
 import java.util.*;
 import java.io.*;
-import java.security.*;
+//import java.security.*;
 
-import java.awt.Frame;
-import java.awt.BorderLayout;
+//import java.awt.Frame;
+//import java.awt.BorderLayout;
 
 // Version definition
 String version = "1.6.0";


### PR DESCRIPTION
Removed import of unused libraries from peregrine.pde (java.security.*, java.awt.Frame, java.awt.BorderLayout).